### PR TITLE
Add model persistence and CLI config

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,20 @@ Alternatively, you can run the notebook from the command line using `jupyter nbc
 jupyter nbconvert --to notebook --execute RLcode --output output.ipynb
 ```
 
+### Command line training
+You can also train the models directly with `train.py`. Hyperparameters can be
+supplied via command line flags or a YAML configuration file:
+
+```bash
+python train.py --grid_size 8 --num_episodes 200
+```
+
+or
+
+```bash
+python train.py --config config.yaml
+```
+
 ## Components
 * **PPO** – The main reinforcement learning algorithm used to learn policies from environment interaction.
 * **ICM** – Adds intrinsic rewards based on prediction error of the agent's dynamics model to promote exploring unseen states.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ torch
 numpy
 matplotlib
 gym
+PyYAML

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,29 @@
+import os
+import torch
+
+def save_model(policy, path, icm=None, rnd=None):
+    """Save policy and optional exploration modules."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    checkpoint = {"policy": policy.state_dict()}
+    if icm is not None:
+        checkpoint["icm"] = icm.state_dict()
+    if rnd is not None:
+        checkpoint["rnd"] = rnd.state_dict()
+    torch.save(checkpoint, path)
+
+
+def load_model(policy_class, input_dim, action_dim, path, icm_class=None, rnd_class=None, device=None):
+    """Load policy and exploration modules from checkpoint."""
+    checkpoint = torch.load(path, map_location=device)
+    policy = policy_class(input_dim, action_dim)
+    policy.load_state_dict(checkpoint["policy"])
+    icm = None
+    rnd = None
+    if icm_class is not None and "icm" in checkpoint:
+        icm = icm_class(input_dim, action_dim)
+        icm.load_state_dict(checkpoint["icm"])
+    if rnd_class is not None and "rnd" in checkpoint:
+        rnd = rnd_class(input_dim)
+        rnd.load_state_dict(checkpoint["rnd"])
+    return policy, icm, rnd
+

--- a/train.py
+++ b/train.py
@@ -1,3 +1,6 @@
+import os
+import argparse
+import yaml
 import torch
 import torch.optim as optim
 
@@ -6,16 +9,45 @@ from src.icm import ICMModule
 from src.rnd import RNDModule
 from src.planner import SymbolicPlanner
 from src.ppo import PPOPolicy, train_agent
+from src.utils import save_model, load_model
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Train or evaluate PPO agents")
+    parser.add_argument("--config", type=str, help="Path to YAML config file", default=None)
+    parser.add_argument("--grid_size", type=int, default=12)
+    parser.add_argument("--num_episodes", type=int, default=500)
+    parser.add_argument("--cost_weight", type=float, default=2.0)
+    parser.add_argument("--risk_weight", type=float, default=3.0)
+    parser.add_argument("--goal_weight", type=float, default=0.5)
+    parser.add_argument("--revisit_penalty", type=float, default=1.0)
+    return parser.parse_args()
 
 
 def main():
-    grid_size = 12
+    args = parse_args()
+    if args.config:
+        with open(args.config, "r") as f:
+            cfg = yaml.safe_load(f)
+        for k, v in cfg.items():
+            setattr(args, k, v)
+
+    grid_size = args.grid_size
     input_dim = 5 * grid_size * grid_size
     action_dim = 4
 
     env = GridWorldICM(grid_size=grid_size)
     icm = ICMModule(input_dim, action_dim)
-    planner = SymbolicPlanner(env.cost_map, env.risk_map, env.goal_pos, env.np_random)
+    planner = SymbolicPlanner(
+        env.cost_map,
+        env.risk_map,
+        env.goal_pos,
+        env.np_random,
+        cost_weight=args.cost_weight,
+        risk_weight=args.risk_weight,
+        goal_weight=args.goal_weight,
+        revisit_penalty=args.revisit_penalty,
+    )
 
     export_benchmark_maps(env, num_maps=10, folder="maps/")
     export_benchmark_maps(env, num_maps=5, folder="test_maps/")
@@ -23,37 +55,118 @@ def main():
     policy_demo = PPOPolicy(input_dim, action_dim)
     visualize_paths_on_benchmark_maps(env, policy_demo, map_folder="maps/", num_maps=9)
 
+    planner_weights = {
+        "cost_weight": args.cost_weight,
+        "risk_weight": args.risk_weight,
+        "goal_weight": args.goal_weight,
+        "revisit_penalty": args.revisit_penalty,
+    }
+
     # PPO only
     ppo_policy = PPOPolicy(input_dim, action_dim)
     opt_ppo = optim.Adam(ppo_policy.parameters(), lr=3e-4)
-    rewards_ppo_only, *_ = train_agent(env, ppo_policy, icm, planner, opt_ppo, opt_ppo,
-                                       use_icm=False, use_planner=False)
+    rewards_ppo_only, *_ = train_agent(
+        env,
+        ppo_policy,
+        icm,
+        planner,
+        opt_ppo,
+        opt_ppo,
+        use_icm=False,
+        use_planner=False,
+        num_episodes=args.num_episodes,
+        planner_weights=planner_weights,
+    )
+    save_model(ppo_policy, os.path.join("checkpoints", "ppo_only.pt"))
 
     # PPO + ICM
     ppo_icm_policy = PPOPolicy(input_dim, action_dim)
     opt_icm_policy = optim.Adam(ppo_icm_policy.parameters(), lr=3e-4)
-    rewards_ppo_icm, *_ = train_agent(env, ppo_icm_policy, icm, planner, opt_icm_policy, opt_icm_policy,
-                                      use_icm=True, use_planner=False)
+    rewards_ppo_icm, *_ = train_agent(
+        env,
+        ppo_icm_policy,
+        icm,
+        planner,
+        opt_icm_policy,
+        opt_icm_policy,
+        use_icm=True,
+        use_planner=False,
+        num_episodes=args.num_episodes,
+        planner_weights=planner_weights,
+    )
+    save_model(ppo_icm_policy, os.path.join("checkpoints", "ppo_icm.pt"), icm=icm)
 
     # PPO + ICM + Planner
     ppo_icm_planner_policy = PPOPolicy(input_dim, action_dim)
     opt_plan_policy = optim.Adam(ppo_icm_planner_policy.parameters(), lr=3e-4)
-    rewards_ppo_icm_plan, *_ = train_agent(env, ppo_icm_planner_policy, icm, planner, opt_plan_policy, opt_plan_policy,
-                                          use_icm=True, use_planner=True)
+    rewards_ppo_icm_plan, *_ = train_agent(
+        env,
+        ppo_icm_planner_policy,
+        icm,
+        planner,
+        opt_plan_policy,
+        opt_plan_policy,
+        use_icm=True,
+        use_planner=True,
+        num_episodes=args.num_episodes,
+        planner_weights=planner_weights,
+    )
+    save_model(
+        ppo_icm_planner_policy,
+        os.path.join("checkpoints", "ppo_icm_planner.pt"),
+        icm=icm,
+    )
 
     # Count-based exploration
     ppo_count_policy = PPOPolicy(input_dim, action_dim)
     opt_count_policy = optim.Adam(ppo_count_policy.parameters(), lr=3e-4)
-    rewards_ppo_count, *_ = train_agent(env, ppo_count_policy, icm, planner, opt_count_policy, opt_count_policy,
-                                        use_icm="count", use_planner=False)
+    rewards_ppo_count, *_ = train_agent(
+        env,
+        ppo_count_policy,
+        icm,
+        planner,
+        opt_count_policy,
+        opt_count_policy,
+        use_icm="count",
+        use_planner=False,
+        num_episodes=args.num_episodes,
+        planner_weights=planner_weights,
+    )
+    save_model(ppo_count_policy, os.path.join("checkpoints", "ppo_count.pt"))
 
     # RND exploration
     ppo_rnd_policy = PPOPolicy(input_dim, action_dim)
     opt_rnd_policy = optim.Adam(ppo_rnd_policy.parameters(), lr=3e-4)
     rnd = RNDModule(input_dim)
     opt_rnd = optim.Adam(rnd.predictor.parameters(), lr=1e-3)
-    rewards_ppo_rnd, *_ = train_agent(env, ppo_rnd_policy, icm, planner, opt_rnd_policy, opt_rnd,
-                                      use_icm="rnd", use_planner=False, rnd=rnd)
+    rewards_ppo_rnd, *_ = train_agent(
+        env,
+        ppo_rnd_policy,
+        icm,
+        planner,
+        opt_rnd_policy,
+        opt_rnd,
+        use_icm="rnd",
+        use_planner=False,
+        rnd=rnd,
+        num_episodes=args.num_episodes,
+        planner_weights=planner_weights,
+    )
+    save_model(
+        ppo_rnd_policy,
+        os.path.join("checkpoints", "ppo_rnd.pt"),
+        rnd=rnd,
+    )
+
+    # Load a saved model for evaluation on benchmark maps
+    eval_policy, _, _ = load_model(
+        PPOPolicy,
+        input_dim,
+        action_dim,
+        os.path.join("checkpoints", "ppo_icm_planner.pt"),
+        icm_class=ICMModule,
+    )
+    visualize_paths_on_benchmark_maps(env, eval_policy, map_folder="maps/", num_maps=3)
 
     models = [ppo_policy, ppo_icm_policy, ppo_icm_planner_policy, ppo_count_policy, ppo_rnd_policy]
     model_names = ['PPO Only', 'PPO + ICM', 'PPO + ICM + Planner', 'PPO + count', 'PPO + RND']


### PR DESCRIPTION
## Summary
- implement model saving/loading utilities
- allow configuring hyperparameters via CLI or YAML file
- save policy/ICM/RND parameters in train script
- load a saved model for evaluation after training
- document CLI usage in README

## Testing
- `python -m py_compile train.py src/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc46c98f88330be77ed0fa0235b16