### PR TITLE
Add separate train and test benchmark maps

### DIFF
--- a/src/env.py
+++ b/src/env.py
@@ -279,11 +279,30 @@ def visualize_paths_on_benchmark_maps(
     plt.show()
 
 
-def export_benchmark_maps(env: GridWorldICM, num_maps: int = 10, folder: str = "maps/"):
-    os.makedirs(folder, exist_ok=True)
-    for i in range(num_maps):
+def export_benchmark_maps(
+    env: GridWorldICM,
+    num_train: int = 15,
+    num_test: int = 5,
+    train_folder: str = "train_maps/",
+    test_folder: str = "test_maps/",
+):
+    """Export benchmark maps for training and testing.
+
+    If no arguments are provided, 15 training maps and 5 testing maps are
+    generated and saved under ``train_folder`` and ``test_folder``
+    respectively.
+    """
+
+    os.makedirs(train_folder, exist_ok=True)
+    os.makedirs(test_folder, exist_ok=True)
+
+    for i in range(num_train):
         env.reset(seed=i)
-        env.save_map(f"{folder}/map_{i:02d}.npz")
+        env.save_map(f"{train_folder}/map_{i:02d}.npz")
+
+    for j in range(num_test):
+        env.reset(seed=num_train + j)
+        env.save_map(f"{test_folder}/map_{j:02d}.npz")
 
 
 def evaluate_on_benchmarks(

--- a/src/ppo.py
+++ b/src/ppo.py
@@ -58,7 +58,7 @@ def train_agent(env, policy: PPOPolicy, icm: ICMModule, planner: SymbolicPlanner
     planner_usage_rate = []
 
     for episode in range(num_episodes):
-        benchmark_map = f"maps/map_00.npz"
+        benchmark_map = f"train_maps/map_00.npz"
         obs, _ = env.reset(seed=42, load_map_path=benchmark_map)
 
         done = False

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -10,8 +10,8 @@ from src.ppo import PPOPolicy, train_agent
 
 def test_short_training_loop(tmp_path):
     env = GridWorldICM(grid_size=4, max_steps=10)
-    os.makedirs("maps", exist_ok=True)
-    env.save_map("maps/map_00.npz")
+    os.makedirs("train_maps", exist_ok=True)
+    env.save_map("train_maps/map_00.npz")
 
     input_dim = 5 * env.grid_size * env.grid_size
     action_dim = 4

--- a/train.py
+++ b/train.py
@@ -62,11 +62,10 @@ def main():
         revisit_penalty=args.revisit_penalty,
     )
 
-    export_benchmark_maps(env, num_maps=10, folder="maps/")
-    export_benchmark_maps(env, num_maps=5, folder="test_maps/")
+    export_benchmark_maps(env, num_train=15, num_test=5)
 
     policy_demo = PPOPolicy(input_dim, action_dim)
-    visualize_paths_on_benchmark_maps(env, policy_demo, map_folder="maps/", num_maps=9)
+    visualize_paths_on_benchmark_maps(env, policy_demo, map_folder="train_maps/", num_maps=9)
 
     planner_weights = {
         "cost_weight": args.cost_weight,
@@ -195,7 +194,7 @@ def main():
         os.path.join("checkpoints", "ppo_icm_planner.pt"),
         icm_class=ICMModule,
     )
-    visualize_paths_on_benchmark_maps(env, eval_policy, map_folder="maps/", num_maps=3)
+    visualize_paths_on_benchmark_maps(env, eval_policy, map_folder="test_maps/", num_maps=3)
 
     models = [
         ppo_policy,
@@ -222,7 +221,7 @@ def main():
         success_rnd,
     ]
     for name, model, successes in zip(model_names, models, success_lists):
-        mean_r, std_r = evaluate_on_benchmarks(env, model, map_folder="maps/", num_maps=10)
+        mean_r, std_r = evaluate_on_benchmarks(env, model, map_folder="test_maps/", num_maps=5)
         success_rate = float(sum(successes)) / len(successes) if successes else 0.0
         results.append(
             {
@@ -237,7 +236,7 @@ def main():
     os.makedirs("results", exist_ok=True)
     generate_results_table(df, os.path.join("results", "benchmark_results.html"))
 
-    plot_model_performance(models, model_names, env)
+    plot_model_performance(models, model_names, env, map_folder="test_maps/", num_maps=5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- split benchmark map export into train and test sets
- update training script to use train/test map folders and evaluate on test maps
- keep training short test working with new folder structure

## Testing
- `pip install -q torch numpy matplotlib gym PyYAML seaborn pandas imageio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68701977d71883309d304ee8259fcc75