### PR TITLE
Separate train/test map sets

### DIFF
--- a/src/env.py
+++ b/src/env.py
@@ -279,11 +279,38 @@ def visualize_paths_on_benchmark_maps(
     plt.show()
 
 
-def export_benchmark_maps(env: GridWorldICM, num_maps: int = 10, folder: str = "maps/"):
-    os.makedirs(folder, exist_ok=True)
-    for i in range(num_maps):
+def export_benchmark_maps(
+    env: GridWorldICM,
+    num_train: int = 15,
+    num_test: int = 5,
+    train_folder: str = "train_maps/",
+    test_folder: str = "test_maps/",
+) -> None:
+    """Generate benchmark maps for training and testing.
+
+    Parameters
+    ----------
+    env : GridWorldICM
+        Environment instance used to generate the maps.
+    num_train : int, optional
+        Number of training maps to create. Defaults to ``15``.
+    num_test : int, optional
+        Number of test maps to create. Defaults to ``5``.
+    train_folder : str, optional
+        Directory where training maps are saved.
+    test_folder : str, optional
+        Directory where test maps are saved.
+    """
+
+    os.makedirs(train_folder, exist_ok=True)
+    for i in range(num_train):
         env.reset(seed=i)
-        env.save_map(f"{folder}/map_{i:02d}.npz")
+        env.save_map(os.path.join(train_folder, f"map_{i:02d}.npz"))
+
+    os.makedirs(test_folder, exist_ok=True)
+    for i in range(num_test):
+        env.reset(seed=num_train + i)
+        env.save_map(os.path.join(test_folder, f"map_{i:02d}.npz"))
 
 
 def evaluate_on_benchmarks(

--- a/train.py
+++ b/train.py
@@ -82,11 +82,12 @@ def main():
         revisit_penalty=args.revisit_penalty,
     )
 
-    export_benchmark_maps(env, num_maps=10, folder="maps/")
-    export_benchmark_maps(env, num_maps=5, folder="test_maps/")
+    export_benchmark_maps(env, num_train=15, num_test=5)
 
     policy_demo = PPOPolicy(input_dim, action_dim)
-    visualize_paths_on_benchmark_maps(env, policy_demo, map_folder="maps/", num_maps=9)
+    visualize_paths_on_benchmark_maps(
+        env, policy_demo, map_folder="train_maps/", num_maps=9
+    )
 
     planner_weights = {
         "cost_weight": args.cost_weight,
@@ -225,7 +226,7 @@ def main():
         os.path.join("checkpoints", "ppo_icm_planner.pt"),
         icm_class=ICMModule,
     )
-    visualize_paths_on_benchmark_maps(env, eval_policy, map_folder="maps/", num_maps=3)
+    visualize_paths_on_benchmark_maps(env, eval_policy, map_folder="test_maps/", num_maps=3)
 
     models = [
         ppo_policy,
@@ -252,7 +253,7 @@ def main():
         success_rnd,
     ]
     for name, model, successes in zip(model_names, models, success_lists):
-        mean_r, std_r = evaluate_on_benchmarks(env, model, map_folder="maps/", num_maps=10)
+        mean_r, std_r = evaluate_on_benchmarks(env, model, map_folder="test_maps/", num_maps=5)
         success_rate = float(sum(successes)) / len(successes) if successes else 0.0
         results.append(
             {
@@ -267,7 +268,7 @@ def main():
     os.makedirs("results", exist_ok=True)
     generate_results_table(df, os.path.join("results", "benchmark_results.html"))
 
-    plot_model_performance(models, model_names, env)
+    plot_model_performance(models, model_names, env, map_folder="test_maps/", num_maps=5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow `export_benchmark_maps` to generate separate train and test maps
- generate train/test map folders in `train.py`
- evaluate models using the test map set

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68702512cf908330b1d4c6f09513493f