### PR TITLE
Add logging backend option

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ seaborn
 pandas
 imageio
 scipy
+wandb
+tensorboard


### PR DESCRIPTION
## Summary
- support `--log_backend` arg for wandb or tensorboard logging
- initialize logger in `main`
- record metrics in `train_agent`
- close logger at end of training
- update requirements

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870c638d8f08330a6b7f3a93b5e9d28