### PR TITLE
Ensure deterministic training

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Train all models from a configuration file:
 ```bash
 python train.py --config configs/default.yaml
 ```
-Checkpoints are saved under `checkpoints/`, episode videos under `videos/`, and result tables under `results/`. Hyperparameters such as planner weights (`cost_weight`, `risk_weight`, etc.) can be edited in the YAML file or passed as command-line flags.
+Checkpoints are saved under `checkpoints/`, episode videos under `videos/`, and result tables under `results/`. Hyperparameters such as planner weights (`cost_weight`, `risk_weight`, etc.) can be edited in the YAML file or passed as command-line flags. The `seed` value in `configs/default.yaml` initializes both NumPy and PyTorch and turns on deterministic CuDNN settings so runs are reproducible.
 
 To repeat an experiment with multiple random seeds you can loop over the `--seed` argument:
 

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -6,4 +6,4 @@ goal_weight: 0.5
 revisit_penalty: 1.0
 dynamic_risk: false
 add_noise: false
-seed: 42
+seed: 42  # used for numpy and torch; enables deterministic CUDNN

--- a/train.py
+++ b/train.py
@@ -101,6 +101,12 @@ def main():
         for k, v in cfg.items():
             setattr(args, k, v)
 
+    # Set random seeds for reproducibility
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+
     logger = None
     if args.log_backend == "tensorboard":
         from torch.utils.tensorboard import SummaryWriter


### PR DESCRIPTION
## Summary
- seed NumPy and PyTorch RNGs in `train.py`
- enable deterministic cudnn execution
- document reproducibility in config and README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6870d52148648330a477f1c325011755