### PR TITLE
Add reproduction instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,17 @@ Execute the unit tests with:
 pytest -q
 ```
 The full suite runs in well under a minute on a CPU.
+
+## Reproducing Our Results
+The provided Dockerfile allows you to recreate the exact environment used for
+our experiments. Run the following commands:
+
+```bash
+git clone <repo-url>
+cd WarzoneRobo
+docker build -t warzonerobo .
+docker run --rm warzonerobo python train.py --config configs/default.yaml
+```
+
+Checkpoints are saved under `checkpoints/` and benchmark tables under
+`results/` within the repository.


### PR DESCRIPTION
## Summary
- add `Reproducing Our Results` section after the tests section
- mention Docker commands for running training
- note where checkpoints and tables are stored

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870d939c4cc83308b0d00af9efa2895