### PR TITLE
Fix training config override and map mismatch

### DIFF
--- a/src/ppo.py
+++ b/src/ppo.py
@@ -1,3 +1,4 @@
+import os
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -72,8 +73,12 @@ def train_agent(
     success_flags = []
     planner_usage_rate = []
 
+    benchmark_map = "maps/map_00.npz"
+    os.makedirs(os.path.dirname(benchmark_map), exist_ok=True)
+    env.reset(seed=seed)
+    env.save_map(benchmark_map)
+
     for episode in range(num_episodes):
-        benchmark_map = f"maps/map_00.npz"
         obs, _ = env.reset(seed=seed, load_map_path=benchmark_map, add_noise=add_noise)
 
         done = False


### PR DESCRIPTION
## Summary
- parse YAML configs as defaults so CLI args override them
- regenerate benchmark map using current environment grid size

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68712e648f8483309a43b7ff6f5328dd