### PR TITLE
Enhance statistical analysis in results

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ python train.py --num_episodes 200
 # CSV and HTML tables are written to the `results/` folder
 ```
 
-Paired t-tests are performed against the PPO baseline for each variant.
-Differences are considered significant when `p < 0.05`.
+Use `--stat-test` to choose the statistical test applied to the aggregated
+results. Available options are `paired`, `welch`, `mannwhitney` and `anova`. The
+default is a paired t-test against the PPO baseline. P-values below `0.05`
+are marked with `*` in the table and those below `0.01` with `**`.
 
 ## Components
 * **PPO** – The main reinforcement learning algorithm used to learn policies from environment interaction.

--- a/src/visualization.py
+++ b/src/visualization.py
@@ -107,6 +107,19 @@ def generate_results_table(df: pd.DataFrame, output_path: str) -> None:
     base, ext = os.path.splitext(output_path)
     os.makedirs(os.path.dirname(base) or ".", exist_ok=True)
 
+    if "Reward p-value" in df.columns:
+        def _mark(p: float) -> str:
+            if pd.isna(p):
+                return ""
+            if p < 0.01:
+                return "**"
+            if p < 0.05:
+                return "*"
+            return ""
+
+        df = df.copy()
+        df["Significance"] = df["Reward p-value"].apply(_mark)
+
     csv_path = base + ".csv"
     df.to_csv(csv_path, index=False)
 


### PR DESCRIPTION
## Summary
- add `--stat-test` argument with multiple test choices
- compute Welch, Mann–Whitney or ANOVA p-values in `train.py`
- show significance markers in generated result tables
- document the new option and significance markers in the README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for gym and torch)*

------
https://chatgpt.com/codex/tasks/task_e_6871791e106c83309d58b50a47a8ff58