### PR TITLE
Fix seeding for multi-run experiments

### DIFF
--- a/train.py
+++ b/train.py
@@ -238,6 +238,8 @@ def main():
         }
 
         for run_seed in seeds:
+            np.random.seed(run_seed)
+            torch.manual_seed(run_seed)
             env.reset(seed=run_seed)
             icm = ICMModule(input_dim, action_dim)
             planner = SymbolicPlanner(


### PR DESCRIPTION
## Summary
- reset numpy and torch RNGs for every seed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy/torch)*

------
https://chatgpt.com/codex/tasks/task_e_686fb6b95d6c83308cc68b8014431170