### PR TITLE
Fix deprecation warning in visualization

### DIFF
--- a/src/visualization.py
+++ b/src/visualization.py
@@ -174,4 +174,6 @@ def render_episode_video(env, policy, output_path: str, max_steps: int = 100, se
         step += 1
 
     os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
-    imageio.mimsave(output_path, frames, fps=5)
+    fps = 5
+    duration = int(1000 / fps)
+    imageio.mimsave(output_path, frames, duration=duration)


### PR DESCRIPTION
## Summary
- address the DeprecationWarning from imageio by using the `duration` argument instead of deprecated `fps`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874a9d13a788330844961a1820fc090