### PR TITLE
Implement dynamic risk around enemies

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ are marked with `*` in the table and those below `0.01` with `**`.
 The notebook experiments with different combinations of these components to evaluate their effect on success rate and exploration.
 
 ## Environment features
-The grid world includes an optional *dynamic risk* mode where risk levels grow as enemies move. Benchmark maps can be exported with `export_benchmark_maps` and loaded later for evaluation. The environment's `render()` method returns RGB frames so that `render_episode_video` can produce GIFs of agent behavior.
+The grid world includes an optional *dynamic risk* mode where risk values around the moving enemies gradually rise and decay over time. Benchmark maps can be exported with `export_benchmark_maps` and loaded later for evaluation. The environment's `render()` method returns RGB frames so that `render_episode_video` can produce GIFs of agent behavior.
 
 ## Running Experiments
 Train all models from a configuration file:

--- a/src/env.py
+++ b/src/env.py
@@ -100,14 +100,22 @@ class GridWorldICM:
         self.agent_pos = [x, y]
 
         self.steps += 1
-        if self.dynamic_risk and self.np_random.rand() < 0.1:
-            i, j = self.np_random.randint(self.grid_size, size=2)
-            self.risk_map[i][j] = min(1.0, self.risk_map[i][j] + 0.5)
 
         for enemy in self.enemy_positions:
             dx, dy = self.np_random.choice([-1, 0, 1], size=2)
             enemy[0] = np.clip(enemy[0] + dx, 0, self.grid_size - 1)
             enemy[1] = np.clip(enemy[1] + dy, 0, self.grid_size - 1)
+
+        if self.dynamic_risk:
+            self.risk_map *= 0.95
+            for ex, ey in self.enemy_positions:
+                self.risk_map[ex, ey] = min(1.0, self.risk_map[ex, ey] + 0.5)
+                for dx, dy in [(-1, 0), (1, 0), (0, -1), (0, 1)]:
+                    nx, ny = ex + dx, ey + dy
+                    if 0 <= nx < self.grid_size and 0 <= ny < self.grid_size:
+                        self.risk_map[nx, ny] = min(
+                            1.0, self.risk_map[nx, ny] + 0.25
+                        )
 
         cost = np.clip(self.cost_map[x][y], 0, 1)
         risk = np.clip(self.risk_map[x][y], 0, 1)

--- a/src/ppo.py
+++ b/src/ppo.py
@@ -176,7 +176,7 @@ def train_agent(
         adv_tensor = torch.tensor(advantages, dtype=torch.float32)
         adv_tensor = (adv_tensor - adv_tensor.mean()) / (adv_tensor.std() + 1e-8)
 
-        obs_tensor = torch.tensor(obs_buf, dtype=torch.float32)
+        obs_tensor = torch.tensor(np.array(obs_buf), dtype=torch.float32)
         action_tensor = torch.tensor(action_buf)
         logprob_tensor = torch.stack(logprob_buf)
         val_tensor = torch.tensor(val_buf, dtype=torch.float32)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -18,3 +18,13 @@ def test_step_boundaries_and_rewards():
     _, reward, _, _, _ = env.step(3)
     assert env.agent_pos == [0, 1]
     assert reward <= -0.7
+
+
+def test_dynamic_risk_updates_near_enemies():
+    env = GridWorldICM(grid_size=3, dynamic_risk=True, max_steps=5, seed=0)
+    env.reset(seed=0)
+    env.risk_map = np.zeros((3, 3))
+    env.enemy_positions = [[1, 1]]
+    env.step(0)
+    ex, ey = env.enemy_positions[0]
+    assert env.risk_map[ex, ey] > 0

--- a/train.py
+++ b/train.py
@@ -254,6 +254,7 @@ def main():
             )
 
         # PPO only
+        print("Training PPO Only")
         ppo_policy = PPOPolicy(input_dim, action_dim)
         opt_ppo = optim.Adam(ppo_policy.parameters(), lr=3e-4)
         rewards_ppo_only, intrinsic_ppo_only, _, _, paths_ppo_only, _, success_ppo_only, planner_rate_ppo_only = train_agent(
@@ -286,6 +287,7 @@ def main():
 
         # PPO + ICM
         if not args.disable_icm:
+            print("Training PPO + ICM")
             ppo_icm_policy = PPOPolicy(input_dim, action_dim)
             opt_icm_policy = optim.Adam(ppo_icm_policy.parameters(), lr=3e-4)
             rewards_ppo_icm, intrinsic_icm, _, _, paths_icm, _, success_icm, planner_rate_icm = train_agent(
@@ -318,6 +320,7 @@ def main():
             bench["PPO + ICM"].append(mean_b)
 
         # PPO + Pseudo-count exploration
+        print("Training PPO + PC")
         ppo_pc_policy = PPOPolicy(input_dim, action_dim)
         opt_pc_policy = optim.Adam(ppo_pc_policy.parameters(), lr=3e-4)
         pseudo = PseudoCountExploration()
@@ -352,6 +355,7 @@ def main():
 
         # PPO + ICM + Planner
         if not args.disable_icm and not args.disable_planner:
+            print("Training PPO + ICM + Planner")
             ppo_icm_planner_policy = PPOPolicy(input_dim, action_dim)
             opt_plan_policy = optim.Adam(ppo_icm_planner_policy.parameters(), lr=3e-4)
             rewards_ppo_icm_plan, intrinsic_plan, _, _, paths_plan, _, success_plan, planner_rate_plan = train_agent(
@@ -400,6 +404,7 @@ def main():
                 plot_heatmap_with_path(env, paths_plan[-1], output_path=heat_path)
 
         # Count-based exploration
+        print("Training PPO + count")
         ppo_count_policy = PPOPolicy(input_dim, action_dim)
         opt_count_policy = optim.Adam(ppo_count_policy.parameters(), lr=3e-4)
         rewards_ppo_count, intrinsic_count, _, _, paths_count, _, success_count, planner_rate_count = train_agent(
@@ -432,6 +437,7 @@ def main():
 
         # RND exploration
         if not args.disable_rnd:
+            print("Training PPO + RND")
             ppo_rnd_policy = PPOPolicy(input_dim, action_dim)
             opt_rnd_policy = optim.Adam(ppo_rnd_policy.parameters(), lr=3e-4)
             rnd = RNDModule(input_dim)


### PR DESCRIPTION
## Summary
- make risk map values grow near enemies when dynamic risk is enabled
- mention dynamic risk behaviour in README
- test that risk updates around enemies

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6874ae4a6d5483308b3e3ddccb7b3873