### PR TITLE
Add dynamic cost map with config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Additional environment options can also be specified in the YAML:
 grid_size: 8
 num_episodes: 200
 dynamic_risk: true      # enemies increase risk over time
+dynamic_cost: true     # cost near mines decays and rises dynamically
 add_noise: true         # perturb loaded maps on reset
 ```
 
@@ -77,7 +78,7 @@ are marked with `*` in the table and those below `0.01` with `**`.
 The notebook experiments with different combinations of these components to evaluate their effect on success rate and exploration.
 
 ## Environment features
-The grid world includes an optional *dynamic risk* mode where risk values around the moving enemies gradually rise and decay over time. Benchmark maps can be exported with `export_benchmark_maps` and loaded later for evaluation. The environment's `render()` method returns RGB frames so that `render_episode_video` can produce GIFs of agent behavior.
+The grid world includes optional *dynamic risk* and *dynamic cost* modes. With dynamic risk enabled, values around moving enemies rise and decay over time. Dynamic cost similarly adjusts the traversal cost map, increasing values near mines while slowly decaying elsewhere. Benchmark maps can be exported with `export_benchmark_maps` and loaded later for evaluation. The environment's `render()` method returns RGB frames so that `render_episode_video` can produce GIFs of agent behavior.
 
 ## Running Experiments
 Train all models from a configuration file:

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -5,5 +5,6 @@ risk_weight: 3.0
 goal_weight: 0.5
 revisit_penalty: 1.0
 dynamic_risk: false
+dynamic_cost: false
 add_noise: false
 seed: 42  # used for numpy and torch; enables deterministic CUDNN

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -28,3 +28,17 @@ def test_dynamic_risk_updates_near_enemies():
     env.step(0)
     ex, ey = env.enemy_positions[0]
     assert env.risk_map[ex, ey] > 0
+
+
+def test_dynamic_cost_updates_near_mines_and_decay():
+    env = GridWorldICM(grid_size=3, dynamic_cost=True, max_steps=5, seed=0)
+    env.reset(seed=0)
+    env.cost_map = np.zeros((3, 3))
+    env.cost_map[0, 0] = 1.0
+    env.mine_map = np.zeros((3, 3), dtype=bool)
+    env.mine_map[1, 1] = True
+    env.step(1)  # move down, avoiding the mine
+    # cost at previous high value should decay
+    assert env.cost_map[0, 0] < 1.0
+    # cost near the mine should increase
+    assert env.cost_map[1, 1] > 0

--- a/train.py
+++ b/train.py
@@ -60,6 +60,7 @@ def parse_args():
     parser.add_argument("--goal_weight", type=float, default=0.5)
     parser.add_argument("--revisit_penalty", type=float, default=1.0)
     parser.add_argument("--dynamic_risk", action="store_true", help="Enable dynamic risk in env")
+    parser.add_argument("--dynamic_cost", action="store_true", help="Enable dynamic cost in env")
     parser.add_argument("--add_noise", action="store_true", help="Add noise when resetting maps")
     parser.add_argument("--seed", type=int, default=42, help="Random seed")
     parser.add_argument(
@@ -159,6 +160,7 @@ def main():
     env = GridWorldICM(
         grid_size=grid_size,
         dynamic_risk=args.dynamic_risk,
+        dynamic_cost=args.dynamic_cost,
         seed=seeds[0],
     )
     icm = ICMModule(input_dim, action_dim)


### PR DESCRIPTION
## Summary
- update `GridWorldICM` to support dynamic cost maps
- decay and raise costs around mines each step
- update `train.py` and configuration to expose `dynamic_cost`
- document new option in README
- test dynamic cost behaviour
- avoid importing torch on module load

## Testing
- `pytest -q` *(fails: Bus error while importing torch)*

------
https://chatgpt.com/codex/tasks/task_e_6874d2dba8f08330936c1692dfcf0759