### PR TITLE
Add survival reward in GridWorld and tests

### DIFF
--- a/src/env.py
+++ b/src/env.py
@@ -17,6 +17,7 @@ class GridWorldICM:
         dynamic_cost: bool = False,
         reward_clip: Tuple[float, float] = (-10, 100),
         max_steps: int = 100,
+        survival_reward: float = 0.0,
         seed: int | None = None,
     ) -> None:
         self.grid_size = grid_size
@@ -24,6 +25,7 @@ class GridWorldICM:
         self.dynamic_cost = dynamic_cost
         self.reward_clip = reward_clip
         self.max_steps = max_steps
+        self.survival_reward = survival_reward
         self.seed(seed)
         self.reset()
 
@@ -136,7 +138,7 @@ class GridWorldICM:
         cost = np.clip(self.cost_map[x][y], 0, 1)
         risk = np.clip(self.risk_map[x][y], 0, 1)
 
-        reward = -cost - risk
+        reward = self.survival_reward - cost - risk
         terrain = self.terrain_map[x][y]
         if terrain == "mud":
             reward -= 0.2 * terrain_decay

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -42,3 +42,14 @@ def test_dynamic_cost_updates_near_mines_and_decay():
     assert env.cost_map[0, 0] < 1.0
     # cost near the mine should increase
     assert env.cost_map[1, 1] > 0
+
+
+def test_survival_reward_positive():
+    env = GridWorldICM(grid_size=2, max_steps=5, survival_reward=0.05)
+    env.reset()
+    env.cost_map = np.zeros((2, 2))
+    env.risk_map = np.zeros((2, 2))
+    env.mine_map = np.zeros((2, 2), dtype=bool)
+    env.enemy_positions = []
+    _, reward, _, _, _ = env.step(1)
+    assert reward > 0


### PR DESCRIPTION
## Summary
- extend `GridWorldICM` constructor with `survival_reward` parameter
- incorporate the survival reward into the step reward computation
- add a unit test validating positive reward when survival reward is used

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874d69bc8a08330a82d6108fedc46d8