### PR TITLE
Update planner scoring logic

### DIFF
--- a/src/planner.py
+++ b/src/planner.py
@@ -2,7 +2,7 @@ import numpy as np
 
 
 class SymbolicPlanner:
-    """A simple scoring-based planner used to select safer actions."""
+    """Scoring-based planner that favors low cost and low risk cells."""
 
     def __init__(
         self,
@@ -31,6 +31,7 @@ class SymbolicPlanner:
             cost = self.cost_map[i][j]
             risk = self.risk_map[i][j]
             revisit = self.revisit_penalty if self.visited_map[i][j] else 0
+            # Candidate score is weighted sum of cost and risk only
             return (
                 self.cost_weight * cost
                 + self.risk_weight * risk

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -11,3 +11,15 @@ def test_get_safe_subgoal_prefers_low_risk():
     assert action in {0, 1, 2, 3}
     # best action should be right (3) as going down has risk
     assert action == 3
+
+
+def test_get_safe_subgoal_prefers_low_cost_when_risk_equal():
+    cost = np.zeros((3, 3))
+    risk = np.zeros((3, 3))
+    cost[0, 1] = 0.8  # right from start has higher cost
+    cost[1, 0] = 0.2  # down from start has lower cost
+    planner = SymbolicPlanner(cost, risk, np_random=np.random.RandomState(1))
+    action = planner.get_safe_subgoal((0, 0))
+    assert action in {0, 1, 2, 3}
+    # best action should be down (1) due to lower cost
+    assert action == 1


### PR DESCRIPTION
## Summary
- document goal-free scoring in `SymbolicPlanner`
- add cost-based planning test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874d9e93bf08330b824f737c5d8b5b8