### PR TITLE
Remove unused goal_weight option

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -2,7 +2,6 @@ grid_size: 8
 num_episodes: 200
 cost_weight: 2.0
 risk_weight: 3.0
-goal_weight: 0.5
 revisit_penalty: 1.0
 dynamic_risk: false
 dynamic_cost: false

--- a/train.py
+++ b/train.py
@@ -57,7 +57,6 @@ def parse_args():
     parser.add_argument("--num_episodes", type=int, default=500)
     parser.add_argument("--cost_weight", type=float, default=2.0)
     parser.add_argument("--risk_weight", type=float, default=3.0)
-    parser.add_argument("--goal_weight", type=float, default=0.5)
     parser.add_argument("--revisit_penalty", type=float, default=1.0)
     parser.add_argument("--dynamic_risk", action="store_true", help="Enable dynamic risk in env")
     parser.add_argument("--dynamic_cost", action="store_true", help="Enable dynamic cost in env")


### PR DESCRIPTION
## Summary
- remove `goal_weight` command line argument
- delete `goal_weight` from default config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874e0e257b48330ab30f025a9ad3a44