### PR TITLE
Update README for survival objective

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 WarzoneRobo contains research code exploring reinforcement learning (RL) techniques for navigating grid based strategy maps. The project compares vanilla policy gradients with techniques that improve exploration or planning.
 
+Unlike a typical navigation task with a goal location, the agent's objective here is long-term survival. Each step incurs cost and risk penalties based on the current maps, so policies must balance movement with staying alive.
+
 ## Project goals
 * Train an agent using Proximal Policy Optimization (PPO).
 * Augment the agent with Intrinsic Curiosity Module (ICM) and Random Network Distillation (RND) to encourage exploration.
@@ -78,7 +80,7 @@ are marked with `*` in the table and those below `0.01` with `**`.
 The notebook experiments with different combinations of these components to evaluate their effect on success rate and exploration.
 
 ## Environment features
-The grid world includes optional *dynamic risk* and *dynamic cost* modes. With dynamic risk enabled, values around moving enemies rise and decay over time. Dynamic cost similarly adjusts the traversal cost map, increasing values near mines while slowly decaying elsewhere. Benchmark maps can be exported with `export_benchmark_maps` and loaded later for evaluation. The environment's `render()` method returns RGB frames so that `render_episode_video` can produce GIFs of agent behavior.
+The grid world includes optional *dynamic risk* and *dynamic cost* modes. With dynamic risk enabled, values around moving enemies rise and decay over time. Dynamic cost similarly adjusts the traversal cost map, increasing values near mines while slowly decaying elsewhere. An optional `survival_reward` adds a small per-step bonus when enabled. Benchmark maps can be exported with `export_benchmark_maps` and loaded later for evaluation. The environment's `render()` method returns RGB frames so that `render_episode_video` can produce GIFs of agent behavior.
 
 ## Running Experiments
 Train all models from a configuration file:


### PR DESCRIPTION
## Summary
- mention survival as the objective rather than reaching a goal
- note optional `survival_reward` along with dynamic risk/cost maps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6874e6817858833080e09dea7ae19e09