### PR TITLE
Add reset logic to planner

### DIFF
--- a/src/planner.py
+++ b/src/planner.py
@@ -22,6 +22,10 @@ class SymbolicPlanner:
         self.grid_size = cost_map.shape[0]
         self.visited_map = np.zeros_like(cost_map, dtype=bool)
 
+    def reset(self):
+        """Clear internal visitation state."""
+        self.visited_map[:] = False
+
     def get_safe_subgoal(self, agent_pos):
         x, y = agent_pos
         directions = {0: (-1, 0), 1: (1, 0), 2: (0, -1), 3: (0, 1)}

--- a/src/ppo.py
+++ b/src/ppo.py
@@ -88,7 +88,7 @@ def train_agent(
         obs_buf, action_buf, logprob_buf, val_buf, reward_buf = [], [], [], [], []
         agent_path = []
         planner_decisions = 0
-        if planner_weights:
+        if planner_weights is not None:
             planner = SymbolicPlanner(
                 env.cost_map,
                 env.risk_map,
@@ -97,6 +97,12 @@ def train_agent(
                 risk_weight=planner_weights.get("risk_weight", 3.0),
                 revisit_penalty=planner_weights.get("revisit_penalty", 1.0),
             )
+        else:
+            planner.cost_map = env.cost_map
+            planner.risk_map = env.risk_map
+            planner.np_random = env.np_random
+            planner.grid_size = env.grid_size
+            planner.reset()
 
         ppo_decisions = 0
         intrinsic_log = 0

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -23,3 +23,13 @@ def test_get_safe_subgoal_prefers_low_cost_when_risk_equal():
     assert action in {0, 1, 2, 3}
     # best action should be down (1) due to lower cost
     assert action == 1
+
+
+def test_planner_reset_clears_visited():
+    cost = np.zeros((2, 2))
+    risk = np.zeros((2, 2))
+    planner = SymbolicPlanner(cost, risk, np_random=np.random.RandomState(2))
+    planner.get_safe_subgoal((0, 0))
+    assert planner.visited_map[0, 0]
+    planner.reset()
+    assert not planner.visited_map.any()


### PR DESCRIPTION
## Summary
- add `reset` method to `SymbolicPlanner`
- reuse planner when no weights provided and clear state
- test planner reset functionality

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy and torch)*

------
https://chatgpt.com/codex/tasks/task_e_6874e7e6a4c08330a7c5084c4af352d1