### PR TITLE
Implement dynamic risk-sensitive planning

### DIFF
--- a/src/env.py
+++ b/src/env.py
@@ -26,6 +26,8 @@ class GridWorldICM:
         self.reward_clip = reward_clip
         self.max_steps = max_steps
         self.survival_reward = survival_reward
+        if seed is None:
+            seed = 0
         self.seed(seed)
         self.reset()
 

--- a/src/ppo.py
+++ b/src/ppo.py
@@ -111,7 +111,21 @@ def train_agent(
 
         while not done:
             state_tensor = torch.tensor(obs, dtype=torch.float32).unsqueeze(0)
-            use_planner_now = use_planner and (env.risk_map[env.agent_pos[0]][env.agent_pos[1]] > 0.5)
+            risk = env.risk_map[env.agent_pos[0]][env.agent_pos[1]]
+            if risk > 0.7:
+                planner.risk_weight = 5.0
+                planner.cost_weight = 1.0
+                use_planner_now = use_planner
+            elif risk > 0.5:
+                planner.risk_weight = 3.0
+                planner.cost_weight = 2.0
+                use_planner_now = use_planner
+            elif risk > 0.2:
+                planner.risk_weight = 1.0
+                planner.cost_weight = 3.0
+                use_planner_now = use_planner
+            else:
+                use_planner_now = False
             used_planner = False
             if use_planner_now:
                 action = planner.get_safe_subgoal(env.agent_pos)


### PR DESCRIPTION
## Summary
- seed environment deterministically when no seed is provided
- adjust planner usage in PPO with dynamic risk thresholds
- maintain all tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68775e922c248330b3d1c0f70f2d625c