### PR TITLE
Implement beta decay schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,20 @@ python train.py --config configs/default.yaml
 Checkpoints are saved under `checkpoints/`, episode videos under `videos/`, and result tables under `results/`. Hyperparameters such as planner weights (`cost_weight`, `risk_weight`, etc.) can be edited in the YAML file or passed as command-line flags. The `seed` value in `configs/default.yaml` initializes both NumPy and PyTorch and turns on deterministic CuDNN settings so runs are reproducible.
 Use `--plot-dir figures/` to save training plots such as reward curves and heatmaps. The directory is created automatically.
 
+Specify `--initial-beta` and `--final-beta` to linearly decay the curiosity
+weight. The value decreases until two thirds of the episodes have completed,
+then stays at the final level. For example:
+
+```bash
+python train.py --initial-beta 0.2 --final-beta 0.05
+```
+
+To measure the effect of curiosity you can disable the ICM module:
+
+```bash
+python train.py --initial-beta 0.2 --final-beta 0.05 --disable_icm
+```
+
 To repeat an experiment with multiple random seeds you can loop over the `--seed` argument:
 
 ```bash

--- a/train.py
+++ b/train.py
@@ -58,6 +58,18 @@ def parse_args():
     parser.add_argument("--cost_weight", type=float, default=2.0)
     parser.add_argument("--risk_weight", type=float, default=3.0)
     parser.add_argument("--revisit_penalty", type=float, default=1.0)
+    parser.add_argument(
+        "--initial-beta",
+        type=float,
+        default=0.1,
+        help="Starting weight for intrinsic reward",
+    )
+    parser.add_argument(
+        "--final-beta",
+        type=float,
+        default=None,
+        help="Final beta value after decay (defaults to initial value)",
+    )
     parser.add_argument("--dynamic_risk", action="store_true", help="Enable dynamic risk in env")
     parser.add_argument("--dynamic_cost", action="store_true", help="Enable dynamic cost in env")
     parser.add_argument("--add_noise", action="store_true", help="Add noise when resetting maps")
@@ -263,6 +275,8 @@ def main():
                 use_icm=False,
                 use_planner=False,
                 num_episodes=args.num_episodes,
+                beta=args.initial_beta,
+                final_beta=args.final_beta,
                 planner_weights=planner_weights,
                 seed=run_seed,
                 add_noise=args.add_noise,
@@ -296,6 +310,8 @@ def main():
                     use_icm=True,
                     use_planner=False,
                     num_episodes=args.num_episodes,
+                    beta=args.initial_beta,
+                    final_beta=args.final_beta,
                     planner_weights=planner_weights,
                     seed=run_seed,
                     add_noise=args.add_noise,
@@ -331,6 +347,8 @@ def main():
                 use_planner=False,
                 pseudo=pseudo,
                 num_episodes=args.num_episodes,
+                beta=args.initial_beta,
+                final_beta=args.final_beta,
                 planner_weights=planner_weights,
                 seed=run_seed,
                 add_noise=args.add_noise,
@@ -364,6 +382,8 @@ def main():
                     use_icm=True,
                     use_planner=True,
                     num_episodes=args.num_episodes,
+                    beta=args.initial_beta,
+                    final_beta=args.final_beta,
                     planner_weights=planner_weights,
                     seed=run_seed,
                     add_noise=args.add_noise,
@@ -413,6 +433,8 @@ def main():
                 use_icm="count",
                 use_planner=False,
                 num_episodes=args.num_episodes,
+                beta=args.initial_beta,
+                final_beta=args.final_beta,
                 planner_weights=planner_weights,
                 seed=run_seed,
                 add_noise=args.add_noise,
@@ -449,6 +471,8 @@ def main():
                     use_planner=False,
                     rnd=rnd,
                     num_episodes=args.num_episodes,
+                    beta=args.initial_beta,
+                    final_beta=args.final_beta,
                     planner_weights=planner_weights,
                     seed=run_seed,
                     add_noise=args.add_noise,


### PR DESCRIPTION
## Summary
- add `--initial-beta` and `--final-beta` CLI args
- document curiosity weight decay and ablation example
- implement linear decay of curiosity weight in `train_agent`
- pass beta values through training script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68776b059bb08330ab15c0a66be60969