### PR TITLE
Enable dynamic environment difficulty

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ are marked with `*` in the table and those below `0.01` with `**`.
 The notebook experiments with different combinations of these components to evaluate their effect on success rate and exploration.
 
 ## Environment features
-The grid world includes optional *dynamic risk* and *dynamic cost* modes. With dynamic risk enabled, values around moving enemies rise and decay over time. Dynamic cost similarly adjusts the traversal cost map, increasing values near mines while slowly decaying elsewhere. An optional `survival_reward` adds a small per-step bonus when enabled. Benchmark maps can be exported with `export_benchmark_maps` and loaded later for evaluation. The environment's `render()` method returns RGB frames so that `render_episode_video` can produce GIFs of agent behavior.
+The grid world includes optional *dynamic risk* and *dynamic cost* modes. When enabled, hazard locations and traversal costs change over time so agents cannot memorize a single map. A small `survival_reward` of `0.05` is given each step. Benchmark maps can be exported with `export_benchmark_maps` and loaded later for evaluation. The environment's `render()` method returns RGB frames so that `render_episode_video` can produce GIFs of agent behavior.
 
 ## Success metric
 An episode is marked as a **success** only when the agent survives for all

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -3,7 +3,8 @@ num_episodes: 200
 cost_weight: 3.0
 risk_weight: 3.0
 revisit_penalty: 2.0
-dynamic_risk: false
-dynamic_cost: false
+survival_reward: 0.05
+dynamic_risk: true
+dynamic_cost: true
 add_noise: false
 seed: 42  # used for numpy and torch; enables deterministic CUDNN

--- a/src/env.py
+++ b/src/env.py
@@ -17,7 +17,7 @@ class GridWorldICM:
         dynamic_cost: bool = False,
         reward_clip: Tuple[float, float] = (-10, 100),
         max_steps: int = 100,
-        survival_reward: float = 0.0,
+        survival_reward: float = 0.05,
         seed: int | None = None,
     ) -> None:
         self.grid_size = grid_size


### PR DESCRIPTION
## Summary
- adjust survival reward default to 0.05
- turn on dynamic risk and cost in default config
- mention these defaults in the documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878a95d57ec8330a4b198d2c3e40256