### PR TITLE
Expose step cost and track episode cost

### DIFF
--- a/src/ppo.py
+++ b/src/ppo.py
@@ -175,7 +175,7 @@ def train_agent(
                 action, logprob, value = policy.act(state_tensor)
                 ppo_decisions += 1
 
-            next_obs, ext_reward, done, _, info = env.step(
+            next_obs, ext_reward, cost_t, done, _, info = env.step(
                 action, terrain_decay=terrain_decay
             )
             x, y = env.agent_pos

--- a/src/visualization.py
+++ b/src/visualization.py
@@ -176,7 +176,7 @@ def render_episode_video(
     while not done and step < max_steps:
         state_tensor = torch.tensor(obs, dtype=torch.float32).unsqueeze(0)
         action, _, _ = policy.act(state_tensor)
-        obs, _, done, _, _ = env.step(action)
+        obs, _, _, done, _, _ = env.step(action)
         frames.append(env.render())
         step += 1
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -15,8 +15,10 @@ def test_step_boundaries_and_rewards():
     assert env.agent_pos == [0, 0]
 
     # move right into cost/risk cell
-    _, reward, _, _, _ = env.step(3)
+    _, reward, cost, _, _, _ = env.step(3)
     assert env.agent_pos == [0, 1]
+    assert np.isclose(cost, 0.6)
+    assert np.isclose(env.episode_cost, 0.6)
     assert reward <= -0.7
 
 
@@ -51,5 +53,5 @@ def test_survival_reward_positive():
     env.risk_map = np.zeros((2, 2))
     env.mine_map = np.zeros((2, 2), dtype=bool)
     env.enemy_positions = []
-    _, reward, _, _, _ = env.step(1)
+    _, reward, _cost, _, _, _ = env.step(1)
     assert reward > 0


### PR DESCRIPTION
## Summary
- return step cost from `GridWorldICM.step` and accumulate total episode cost
- adjust environment callers and tests for new `(obs, reward, cost, done, truncated, info)` signature
- reset episode cost in `GridWorldICM.reset`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ad88885508330805d1a39f4548c33