### PR TITLE
Add adaptive cost constraint via lambda update

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -3,6 +3,8 @@ num_episodes: 200
 cost_weight: 3.0
 risk_weight: 3.0
 revisit_penalty: 2.0
+eta_lambda: 0.01
+d: 1.0
 survival_reward: 0.05
 dynamic_risk: true
 dynamic_cost: true

--- a/train.py
+++ b/train.py
@@ -62,6 +62,18 @@ def parse_args():
     parser.add_argument("--risk_weight", type=float, default=3.0)
     parser.add_argument("--revisit_penalty", type=float, default=1.0)
     parser.add_argument(
+        "--eta_lambda",
+        type=float,
+        default=0.01,
+        help="Learning rate for lambda update",
+    )
+    parser.add_argument(
+        "--d",
+        type=float,
+        default=1.0,
+        help="Cost threshold for constraint",
+    )
+    parser.add_argument(
         "--initial-beta",
         type=float,
         default=0.1,
@@ -357,6 +369,8 @@ def main():
                 seed=run_seed,
                 add_noise=args.add_noise,
                 logger=logger,
+                eta_lambda=args.eta_lambda,
+                d=args.d,
             )
             metrics["PPO Only"]["rewards"].append(
                 float(np.mean(rewards_ppo_only)))
@@ -416,6 +430,8 @@ def main():
                     seed=run_seed,
                     add_noise=args.add_noise,
                     logger=logger,
+                    eta_lambda=args.eta_lambda,
+                    d=args.d,
                 )
                 metrics["PPO + ICM"]["rewards"].append(
                     float(np.mean(rewards_ppo_icm)))
@@ -478,6 +494,8 @@ def main():
                 seed=run_seed,
                 add_noise=args.add_noise,
                 logger=logger,
+                eta_lambda=args.eta_lambda,
+                d=args.d,
             )
             metrics["PPO + PC"]["rewards"].append(float(np.mean(rewards_pc)))
             metrics["PPO + PC"]["success"].append(
@@ -535,6 +553,8 @@ def main():
                     seed=run_seed,
                     add_noise=args.add_noise,
                     logger=logger,
+                    eta_lambda=args.eta_lambda,
+                    d=args.d,
                 )
                 metrics["PPO + ICM + Planner"]["rewards"].append(
                     float(np.mean(rewards_ppo_icm_plan)))
@@ -614,6 +634,8 @@ def main():
                 seed=run_seed,
                 add_noise=args.add_noise,
                 logger=logger,
+                eta_lambda=args.eta_lambda,
+                d=args.d,
             )
             metrics["PPO + count"]["rewards"].append(
                 float(np.mean(rewards_ppo_count))
@@ -678,6 +700,8 @@ def main():
                     seed=run_seed,
                     add_noise=args.add_noise,
                     logger=logger,
+                    eta_lambda=args.eta_lambda,
+                    d=args.d,
                 )
                 metrics["PPO + RND"]["rewards"].append(
                     float(np.mean(rewards_ppo_rnd)))


### PR DESCRIPTION
## Summary
- Track and update Lagrange multiplier `lambda_val` after each episode and log it
- Expose cost-threshold `d` and learning rate `eta_lambda` via CLI/config and pass to training

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ae8f7d98c833082abfd4b1c8c2a2c