### PR TITLE
Add simple world model and Dyna-style imagination updates

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -16,3 +16,5 @@ seed: 42  # used for numpy and torch; enables deterministic CUDNN
 tau: 0.6
 H: 8
 waypoint_bonus: 0.05
+K: 10
+world_model_lr: 0.001

--- a/src/world_model.py
+++ b/src/world_model.py
@@ -1,0 +1,45 @@
+import random
+from collections import deque
+from typing import Deque, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class WorldModel(nn.Module):
+    """Simple dynamics model f_psi predicting next state from (s, a)."""
+
+    def __init__(self, state_dim: int, action_dim: int, hidden_dim: int = 128):
+        super().__init__()
+        self.fc1 = nn.Linear(state_dim + action_dim, hidden_dim)
+        self.fc2 = nn.Linear(hidden_dim, state_dim)
+
+    def forward(self, state: torch.Tensor, action: torch.Tensor) -> torch.Tensor:
+        """Predict next state given current state and one-hot action."""
+        x = torch.cat([state, action], dim=-1)
+        x = F.relu(self.fc1(x))
+        return self.fc2(x)
+
+
+class ReplayBuffer:
+    """Fixed-size buffer to store environment transitions."""
+
+    def __init__(self, capacity: int = 10000):
+        self.buffer: Deque[Tuple[np.ndarray, int, np.ndarray]] = deque(maxlen=capacity)
+
+    def add(self, state: np.ndarray, action: int, next_state: np.ndarray) -> None:
+        self.buffer.append((state, action, next_state))
+
+    def sample(self, batch_size: int):
+        batch = random.sample(self.buffer, min(batch_size, len(self.buffer)))
+        states, actions, next_states = zip(*batch)
+        return (
+            np.array(states, dtype=np.float32),
+            np.array(actions, dtype=np.int64),
+            np.array(next_states, dtype=np.float32),
+        )
+
+    def __len__(self) -> int:
+        return len(self.buffer)

--- a/train.py
+++ b/train.py
@@ -157,6 +157,18 @@ def parse_args():
         help="Reward bonus for moving toward subgoal",
     )
     parser.add_argument(
+        "--K",
+        type=int,
+        default=10,
+        help="Number of model-based transitions per real step",
+    )
+    parser.add_argument(
+        "--world_model_lr",
+        type=float,
+        default=1e-3,
+        help="Learning rate for the world model",
+    )
+    parser.add_argument(
         "--ablation",
         action="store_true",
         help="Loop over disabling ICM, RND and the planner individually",
@@ -416,6 +428,8 @@ def main():
                 use_risk_penalty=not args.disable_risk_penalty,
                 H=args.H,
                 waypoint_bonus=args.waypoint_bonus,
+                imagination_k=args.K,
+                world_model_lr=args.world_model_lr,
             )
             metrics["PPO Only"]["rewards"].append(
                 float(np.mean(rewards_ppo_only)))
@@ -487,6 +501,8 @@ def main():
                     use_risk_penalty=not args.disable_risk_penalty,
                     H=args.H,
                     waypoint_bonus=args.waypoint_bonus,
+                    imagination_k=args.K,
+                    world_model_lr=args.world_model_lr,
                 )
                 metrics["PPO + ICM"]["rewards"].append(
                     float(np.mean(rewards_ppo_icm)))
@@ -561,6 +577,8 @@ def main():
                 use_risk_penalty=not args.disable_risk_penalty,
                 H=args.H,
                 waypoint_bonus=args.waypoint_bonus,
+                imagination_k=args.K,
+                world_model_lr=args.world_model_lr,
             )
             metrics["PPO + PC"]["rewards"].append(float(np.mean(rewards_pc)))
             metrics["PPO + PC"]["success"].append(
@@ -630,6 +648,8 @@ def main():
                     use_risk_penalty=not args.disable_risk_penalty,
                     H=args.H,
                     waypoint_bonus=args.waypoint_bonus,
+                    imagination_k=args.K,
+                    world_model_lr=args.world_model_lr,
                 )
                 metrics["PPO + ICM + Planner"]["rewards"].append(
                     float(np.mean(rewards_ppo_icm_plan)))
@@ -721,6 +741,8 @@ def main():
                 use_risk_penalty=not args.disable_risk_penalty,
                 H=args.H,
                 waypoint_bonus=args.waypoint_bonus,
+                imagination_k=args.K,
+                world_model_lr=args.world_model_lr,
             )
             metrics["PPO + count"]["rewards"].append(
                 float(np.mean(rewards_ppo_count))
@@ -797,6 +819,8 @@ def main():
                     use_risk_penalty=not args.disable_risk_penalty,
                     H=args.H,
                     waypoint_bonus=args.waypoint_bonus,
+                    imagination_k=args.K,
+                    world_model_lr=args.world_model_lr,
                 )
                 metrics["PPO + RND"]["rewards"].append(
                     float(np.mean(rewards_ppo_rnd)))


### PR DESCRIPTION
## Summary
- add `WorldModel` dynamics network with replay buffer
- augment PPO training with one-step imagination updates
- expose imagination steps `K` and world model learning rate in configs and CLI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b0a35134c833087ff8ad91cc004a4