### PR TITLE
Expose risk and planning parameters in default config

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -14,6 +14,7 @@ dynamic_cost: true
 add_noise: false
 seed: 42  # used for numpy and torch; enables deterministic CUDNN
 tau: 0.6
+kappa: 2.0
 H: 8
 waypoint_bonus: 0.05
 K: 10


### PR DESCRIPTION
## Summary
- Add kappa to `configs/default.yaml` alongside tau, subgoal horizon H, waypoint bonus, and fantasy rollout count K
- Confirm these values are parsed by `train.py` and passed into `train_agent` for training

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b0e45a65c8330a7b6b746abd3c194