### PR TITLE
Add OOD map generation and evaluation

### DIFF
--- a/train.py
+++ b/train.py
@@ -276,7 +276,7 @@ def main():
         revisit_penalty=args.revisit_penalty,
     )
 
-    export_benchmark_maps(env, num_train=15, num_test=5)
+    export_benchmark_maps(env)
 
     policy_demo = PPOPolicy(input_dim, action_dim)
     visualize_paths_on_benchmark_maps(


### PR DESCRIPTION
## Summary
- Generate 20 training, 10 test, and 10 OOD benchmark maps with varied mine densities and enemy behaviors
- Extend evaluation utilities and plotting to report out-of-distribution performance
- Add tests for new benchmark counts and OOD evaluation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689b6678efd88330ab2bdf5818998162