### PR TITLE
Add configurable beta schedule for intrinsic reward

### DIFF
--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -5,7 +5,8 @@ import pytest
 from src.env import GridWorldICM
 from src.icm import ICMModule
 from src.planner import SymbolicPlanner
-from src.ppo import PPOPolicy, train_agent
+from src.pseudocount import PseudoCountExploration
+from src.ppo import PPOPolicy, train_agent, get_beta_schedule
 import yaml
 import numpy as np
 
@@ -85,52 +86,29 @@ def test_training_one_episode_metrics(tmp_path, budget):
 
     assert len(metrics_list) == 10
     metrics = metrics_list[0]
-    if len(metrics) == 19:
-        (
-            rewards,
-            _,
-            _,
-            _,
-            _,
-            _,
-            success_flags,
-            _,
-            _,
-            _,
-            _,
-            coverage_log,
-            _,
-            episode_costs,
-            violation_flags,
-            first_violation_episode,
-            episode_times,
-            steps_per_sec,
-            wall_clock,
-        ) = metrics
-        lambda_log = [0.0] * len(rewards)
-    else:
-        (
-            rewards,
-            _,
-            _,
-            _,
-            _,
-            _,
-            success_flags,
-            _,
-            _,
-            _,
-            _,
-            coverage_log,
-            _,
-            episode_costs,
-            violation_flags,
-            lambda_log,
-            first_violation_episode,
-            episode_times,
-            steps_per_sec,
-            wall_clock,
-        ) = metrics
+    (
+        rewards,
+        _,
+        _,
+        _,
+        _,
+        _,
+        success_flags,
+        _,
+        _,
+        _,
+        _,
+        coverage_log,
+        _,
+        episode_costs,
+        violation_flags,
+        first_violation_episode,
+        episode_times,
+        steps_per_sec,
+        wall_clock,
+        beta_log,
+    ) = metrics
+    lambda_log = [0.0] * len(rewards)
     assert len(rewards) == 1
     assert len(coverage_log) == 1
     assert len(episode_costs) == 1
@@ -139,6 +117,7 @@ def test_training_one_episode_metrics(tmp_path, budget):
     assert len(steps_per_sec) == 1
     assert len(wall_clock) == 1
     assert len(lambda_log) == 1
+    assert len(beta_log) == 1
     assert isinstance(first_violation_episode, int)
 
 
@@ -181,3 +160,56 @@ def test_success_flag_survival(tmp_path, budget):
 
         _, _, _, _, _, _, success_flags, *_rest = metrics
         assert success_flags == [1]
+
+
+def test_beta_schedule_consistency():
+    env = GridWorldICM(grid_size=4, max_steps=5)
+    os.makedirs("maps", exist_ok=True)
+    env.save_map("maps/map_00.npz")
+    input_dim = 4 * env.grid_size * env.grid_size + 2
+    action_dim = 4
+
+    schedule = get_beta_schedule(3, 0.2, 0.1)
+
+    policy1 = PPOPolicy(input_dim, action_dim)
+    icm1 = ICMModule(input_dim, action_dim)
+    planner1 = SymbolicPlanner(env.cost_map, env.risk_map, env.np_random)
+    opt1 = optim.Adam(policy1.parameters(), lr=1e-3)
+    metrics1 = train_agent(
+        env,
+        policy1,
+        icm1,
+        planner1,
+        opt1,
+        opt1,
+        use_icm=True,
+        use_planner=False,
+        num_episodes=3,
+        beta_schedule=schedule,
+    )
+    beta_log1 = metrics1[-1]
+
+    env.reset()
+    policy2 = PPOPolicy(input_dim, action_dim)
+    icm2 = ICMModule(input_dim, action_dim)
+    planner2 = SymbolicPlanner(env.cost_map, env.risk_map, env.np_random)
+    pseudo = PseudoCountExploration()
+    opt2 = optim.Adam(policy2.parameters(), lr=1e-3)
+    metrics2 = train_agent(
+        env,
+        policy2,
+        icm2,
+        planner2,
+        opt2,
+        opt2,
+        use_icm="pseudo",
+        use_planner=False,
+        pseudo=pseudo,
+        num_episodes=3,
+        beta_schedule=schedule,
+    )
+    beta_log2 = metrics2[-1]
+
+    assert beta_log1 == schedule
+    assert beta_log2 == schedule
+    assert beta_log1 == beta_log2

--- a/train.py
+++ b/train.py
@@ -31,7 +31,7 @@ from src.icm import ICMModule
 from src.rnd import RNDModule
 from src.pseudocount import PseudoCountExploration
 from src.planner import SymbolicPlanner
-from src.ppo import PPOPolicy, train_agent
+from src.ppo import PPOPolicy, train_agent, get_beta_schedule
 from src.utils import save_model, count_intrinsic_spikes
 
 
@@ -536,6 +536,9 @@ def run(args):
                 risk_weight=args.risk_weight,
                 revisit_penalty=args.revisit_penalty,
             )
+            beta_schedule = get_beta_schedule(
+                args.num_episodes, args.initial_beta, args.final_beta
+            )
 
             # PPO only
             print("Training PPO Only")
@@ -679,8 +682,7 @@ def run(args):
                     use_icm=True,
                     use_planner=False,
                     num_episodes=args.num_episodes,
-                    beta=args.initial_beta,
-                    final_beta=args.final_beta,
+                    beta_schedule=beta_schedule,
                     planner_weights=planner_weights,
                     seed=run_seed,
                     add_noise=args.add_noise,
@@ -790,8 +792,7 @@ def run(args):
                 use_planner=False,
                 pseudo=pseudo,
                 num_episodes=args.num_episodes,
-                beta=args.initial_beta,
-                final_beta=args.final_beta,
+                beta_schedule=beta_schedule,
                 planner_weights=planner_weights,
                 seed=run_seed,
                 add_noise=args.add_noise,
@@ -896,8 +897,7 @@ def run(args):
                     use_icm=True,
                     use_planner=True,
                     num_episodes=args.num_episodes,
-                    beta=args.initial_beta,
-                    final_beta=args.final_beta,
+                    beta_schedule=beta_schedule,
                     planner_weights=planner_weights,
                     seed=run_seed,
                     add_noise=args.add_noise,
@@ -1024,8 +1024,7 @@ def run(args):
                 use_icm="count",
                 use_planner=False,
                 num_episodes=args.num_episodes,
-                beta=args.initial_beta,
-                final_beta=args.final_beta,
+                beta_schedule=beta_schedule,
                 planner_weights=planner_weights,
                 seed=run_seed,
                 add_noise=args.add_noise,
@@ -1137,8 +1136,7 @@ def run(args):
                     use_planner=False,
                     rnd=rnd,
                     num_episodes=args.num_episodes,
-                    beta=args.initial_beta,
-                    final_beta=args.final_beta,
+                    beta_schedule=beta_schedule,
                     planner_weights=planner_weights,
                     seed=run_seed,
                     add_noise=args.add_noise,


### PR DESCRIPTION
## Summary
- add `get_beta_schedule` helper to precompute beta decay
- log beta schedule and per-episode usage in `train_agent`
- compute beta schedule once per run and share across ICM-based methods
- test beta schedule consistency and update metrics parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b984e68988330b66d52613ad1669a