### PR TITLE
Use bootstrap confidence intervals for binary metrics

### DIFF
--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -7,7 +7,12 @@ from src.icm import ICMModule
 from src.planner import SymbolicPlanner
 from src.pseudocount import PseudoCountExploration
 from src.ppo import PPOPolicy, train_agent, get_beta_schedule
-from train import evaluate_policy_on_maps, get_paired_arrays, compute_cohens_d
+from train import (
+    evaluate_policy_on_maps,
+    get_paired_arrays,
+    compute_cohens_d,
+    bootstrap_ci,
+)
 from scipy.stats import ttest_rel
 from statsmodels.stats.multitest import multipletests
 import yaml
@@ -323,3 +328,15 @@ def test_effect_size_and_holm_adjustment():
         expected[idx] = min(1.0, prev)
 
     assert padj == pytest.approx(expected)
+
+
+def test_bootstrap_ci_shrinkage():
+    np.random.seed(0)
+    small = np.random.binomial(1, 0.5, size=20)
+    np.random.seed(1)
+    large = np.random.binomial(1, 0.5, size=200)
+    np.random.seed(0)
+    _, ci_small = bootstrap_ci(small, n_resamples=1000)
+    np.random.seed(0)
+    _, ci_large = bootstrap_ci(large, n_resamples=1000)
+    assert ci_large < ci_small


### PR DESCRIPTION
## Summary
- add `bootstrap_ci` helper for percentile-based CIs
- format success and violation rates with bootstrapped CIs
- test that bootstrap CI width decreases with sample size

## Testing
- `pytest tests/test_training.py::test_bootstrap_ci_shrinkage -q`
- `pytest tests/test_training.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c2b09e92483309fb403d10ce2ee42