### PR TITLE
Add main results table generation and unit test

### DIFF
--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -4,6 +4,8 @@ import pingouin as pg
 from statsmodels.stats.oneway import anova_oneway
 from statsmodels.stats.multitest import multipletests
 from scipy.stats import friedmanchisquare
+from train import MAIN_METHODS, NAME_MAP, build_main_table
+from src.visualization import generate_results_table
 
 
 def test_welch_anova_gameshowell():
@@ -35,3 +37,47 @@ def test_friedman_statistic():
     method2 = [3, 4, 5, 6, 7]
     stat, p = friedmanchisquare(baseline, method1, method2)
     assert p < 0.05
+
+
+def test_main_results_table(tmp_path):
+    raw_names = [
+        "PPO Only",
+        "PPO + ICM",
+        "PPO + RND",
+        "PPO + count",
+        "PPO + PC",
+        "PPO + ICM + Planner",
+        "LPPO",
+        "Shielded-PPO",
+        "Planner-only",
+        "Planner-Subgoal PPO",
+        "Dyna-PPO(1)",
+    ]
+
+    data = [
+        {
+            "Model": name,
+            "Train Reward": "1.00 ± 0.00",
+            "Success": "1.00 ± 0.00",
+            "Train Cost": "1.00 ± 0.00",
+            "Pr[Jc > d]": "0.00 ± 0.00",
+        }
+        for name in raw_names
+    ]
+
+    df_train = pd.DataFrame(data)
+    df_train["Model"] = df_train["Model"].replace(NAME_MAP)
+    df_main = build_main_table(df_train)
+
+    assert list(df_main.columns) == [
+        "Model",
+        "Train Reward",
+        "Success",
+        "Train Cost",
+        "Pr[Jc > d]",
+    ]
+    assert len(df_main) == len(MAIN_METHODS)
+
+    output_path = tmp_path / "main_table.html"
+    generate_results_table(df_main, str(output_path))
+    assert output_path.exists()


### PR DESCRIPTION
## Summary
- Build canonical main results table from training metrics
- Map internal model names to canonical labels and save as `results/main_table.html`
- Add unit test ensuring table includes expected columns and rows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c33c360b4833081f3f46cc244dbb4