### PR TITLE
Expose beta decay config for ICM training

### DIFF
--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -16,6 +16,8 @@ add_noise: false
 seed: 42  # used for numpy and torch; enables deterministic CUDNN
 tau: 0.7
 kappa: 4.0
+initial_beta: 0.1
+final_beta: 0.01
 H: 8
 waypoint_bonus: 0.05
 K: 10

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -181,7 +181,7 @@ def test_beta_schedule_consistency():
     input_dim = 4 * env.grid_size * env.grid_size + 2
     action_dim = 4
 
-    schedule = get_beta_schedule(3, 0.2, 0.1)
+    schedule = get_beta_schedule(3, 0.1, 0.01)
 
     policy1 = PPOPolicy(input_dim, action_dim)
     icm1 = ICMModule(input_dim, action_dim)

--- a/train.py
+++ b/train.py
@@ -383,8 +383,8 @@ def parse_args():
     parser.add_argument(
         "--final-beta",
         type=float,
-        default=None,
-        help="Final beta value after decay (defaults to initial value)",
+        default=0.01,
+        help="Final beta value after decay",
     )
     parser.add_argument(
         "--dynamic_risk",
@@ -945,6 +945,7 @@ def run(args):
                     use_planner=False,
                     num_episodes=args.num_episodes,
                     beta_schedule=beta_schedule,
+                    final_beta=args.final_beta,
                     planner_weights=planner_weights,
                     seed=run_seed,
                     add_noise=args.add_noise,
@@ -1171,6 +1172,7 @@ def run(args):
                     use_planner=True,
                     num_episodes=args.num_episodes,
                     beta_schedule=beta_schedule,
+                    final_beta=args.final_beta,
                     planner_weights=planner_weights,
                     seed=run_seed,
                     add_noise=args.add_noise,


### PR DESCRIPTION
## Summary
- add `initial_beta` and `final_beta` to default config
- parse and propagate `final_beta` in training including ICM methods
- align unit tests with new beta schedule defaults

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689cb6ed7ee48330ae24dbd26dbba757