### PR TITLE
Aggregate global Pareto data and add regression test

### DIFF
--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -52,6 +52,21 @@ def test_plot_learning_panels(tmp_path):
     assert output.exists()
 
 
+def test_plot_pareto_multiple_methods(tmp_path):
+    df = pd.DataFrame(
+        {
+            "Model": ["A", "B", "C"],
+            "Reward Mean": [1.0, 2.0, 3.0],
+            "Reward CI": [0.1, 0.2, 0.3],
+            "Cost Mean": [0.4, 0.5, 0.6],
+            "Cost CI": [0.04, 0.05, 0.06],
+        }
+    )
+    output = tmp_path / "pareto_multi.pdf"
+    plot_pareto(df, 0.55, str(output))
+    assert output.exists()
+
+
 def test_plot_violation_rate(tmp_path):
     logs = [[0, 1, 0, 1, 0], [0, 0, 1, 0, 0]]
     output = tmp_path / "violation.pdf"


### PR DESCRIPTION
## Summary
- Aggregate mean reward and cost (with 95% CIs) across all methods after training and plot a single Pareto frontier per budget
- Save the combined Pareto plot to `figures/budget_{d}/pareto_all.pdf`
- Add regression test ensuring `plot_pareto` handles multiple methods

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d71424758833080b90c1ef5d50cd3