### PR TITLE
Add violation comparison plotting and integrate into training

### DIFF
--- a/src/visualization.py
+++ b/src/visualization.py
@@ -138,6 +138,74 @@ def plot_violation_rate(logs: list[list[float]] | None, output_path: str | None 
     plt.show()
 
 
+def plot_violation_comparison(
+    method_logs: dict[str, list[list[float]]], output_path: str | None = None
+) -> None:
+    """Overlay mean violation rates with 95% CI bands for each method.
+
+    Parameters
+    ----------
+    method_logs:
+        Mapping from method name to a list of violation flag sequences, one per
+        seed. Each sequence should be a list of binary values indicating whether
+        a constraint violation occurred on that episode.
+    output_path:
+        Optional path to save the resulting figure. The file format is inferred
+        from the extension and defaults to PDF.
+    """
+
+    if not method_logs:
+        return
+
+    sns.set(style="darkgrid")
+    fig, ax = plt.subplots(figsize=(6, 4))
+
+    plotted = False
+    for name, logs in method_logs.items():
+        if not logs:
+            continue
+        if logs and not isinstance(logs[0], (list, np.ndarray)):
+            logs = [logs]
+
+        rates = [
+            np.cumsum(seed) / (np.arange(len(seed)) + 1)
+            for seed in logs
+        ]
+        min_len = min(len(r) for r in rates)
+        arr = np.stack([r[:min_len] for r in rates])
+        episodes = np.arange(1, min_len + 1)
+
+        mean = arr.mean(axis=0)
+        n = arr.shape[0]
+        if n > 1:
+            sem = arr.std(axis=0, ddof=1) / np.sqrt(n)
+            ci = 1.96 * sem
+        else:
+            ci = np.zeros_like(mean)
+
+        ax.plot(episodes, mean, label=name)
+        ax.fill_between(episodes, mean - ci, mean + ci, alpha=0.3)
+        plotted = True
+
+    if not plotted:
+        plt.close(fig)
+        return
+
+    ax.set_ylim(0, 1)
+    ax.set_xlabel("Episode")
+    ax.set_ylabel("Violation Probability")
+    ax.set_title("Constraint Violation Comparison")
+    ax.legend()
+
+    plt.tight_layout()
+    if output_path is not None:
+        os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+        ext = os.path.splitext(output_path)[1].lower()
+        fmt = "svg" if ext == ".svg" else "pdf"
+        plt.savefig(output_path, format=fmt)
+    plt.show()
+
+
 def plot_learning_panels(
     metrics_dict: dict[str, dict[str, list[list[float]]]],
     output_path: str | None = None,

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -10,6 +10,7 @@ from src.visualization import (
     plot_violation_rate,
     plot_coverage_heatmap,
     plot_ablation_radar,
+    plot_violation_comparison,
 )
 
 
@@ -71,6 +72,18 @@ def test_plot_violation_rate(tmp_path):
     logs = [[0, 1, 0, 1, 0], [0, 0, 1, 0, 0]]
     output = tmp_path / "violation.pdf"
     plot_violation_rate(logs, str(output))
+    assert output.exists()
+
+
+def test_plot_violation_comparison(tmp_path):
+    logs = {
+        "PPO Only": [[0, 1, 0], [0, 0, 1]],
+        "LPPO": [[0, 0, 0], [0, 1, 0]],
+        "Shielded-PPO": [[0, 0, 0, 0], [0, 0, 1, 0]],
+        "PPO + ICM + Planner": [[1, 0, 0], [0, 1, 1]],
+    }
+    output = tmp_path / "violation_compare.pdf"
+    plot_violation_comparison(logs, str(output))
     assert output.exists()
 
 

--- a/train.py
+++ b/train.py
@@ -34,6 +34,7 @@ from src.visualization import (
     generate_results_table,
     render_episode_video,
     plot_violation_rate,
+    plot_violation_comparison,
 )
 from src.icm import ICMModule
 from src.rnd import RNDModule
@@ -1559,6 +1560,22 @@ def run(args):
                         logs_dict["violation_flags"], output_path=out_file_vr
                     )
                 panel_logs[name] = metrics_to_plot
+
+        comparison_logs: dict[str, list[list[float]]] = {}
+        for method in [
+            "PPO Only",
+            "LPPO",
+            "Shielded-PPO",
+            "PPO + ICM + Planner",
+        ]:
+            logs = curve_logs.get(method, {}).get("violation_flags", [])
+            if logs:
+                comparison_logs[method] = logs
+        if comparison_logs:
+            cmp_path = None
+            if plot_dir:
+                cmp_path = os.path.join(plot_dir, "violation_compare.pdf")
+            plot_violation_comparison(comparison_logs, output_path=cmp_path)
         if panel_logs:
             out_file = None
             if plot_dir:


### PR DESCRIPTION
## Summary
- Implement `plot_violation_comparison` to overlay mean violation rates with 95% confidence bands
- Integrate comparison plotting into training workflow and gather violation flags for key methods
- Test visualization utility with dummy data

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d768888e88330ba7f74989fec0fdc