### PR TITLE
Add violation comparison visualization with 95% CI

### DIFF
--- a/src/visualization.py
+++ b/src/visualization.py
@@ -167,24 +167,22 @@ def plot_violation_comparison(
         if logs and not isinstance(logs[0], (list, np.ndarray)):
             logs = [logs]
 
+        # Convert violation flags to running probabilities for each seed
         rates = [
             np.cumsum(seed) / (np.arange(len(seed)) + 1)
             for seed in logs
         ]
-        min_len = min(len(r) for r in rates)
-        arr = np.stack([r[:min_len] for r in rates])
-        episodes = np.arange(1, min_len + 1)
-
-        mean = arr.mean(axis=0)
-        n = arr.shape[0]
-        if n > 1:
-            sem = arr.std(axis=0, ddof=1) / np.sqrt(n)
-            ci = 1.96 * sem
-        else:
-            ci = np.zeros_like(mean)
-
-        ax.plot(episodes, mean, label=name)
-        ax.fill_between(episodes, mean - ci, mean + ci, alpha=0.3)
+        df = _stack_logs(rates, "Rate")
+        if df.empty:
+            continue
+        sns.lineplot(
+            data=df,
+            x="Episode",
+            y="Rate",
+            errorbar=("ci", 95),
+            ax=ax,
+            label=name,
+        )
         plotted = True
 
     if not plotted:

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -77,10 +77,12 @@ def test_plot_violation_rate(tmp_path):
 
 def test_plot_violation_comparison(tmp_path):
     logs = {
-        "PPO Only": [[0, 1, 0], [0, 0, 1]],
-        "LPPO": [[0, 0, 0], [0, 1, 0]],
-        "Shielded-PPO": [[0, 0, 0, 0], [0, 0, 1, 0]],
-        "PPO + ICM + Planner": [[1, 0, 0], [0, 1, 1]],
+        # Different seeds have different episode lengths to ensure the
+        # comparison routine can handle variable-length logs.
+        "PPO Only": [[0, 1, 0], [0, 0, 1, 1]],
+        "LPPO": [[0, 0], [0, 1, 0]],
+        "Shielded-PPO": [[0, 0, 0], [0, 0, 1, 0, 0]],
+        "PPO + ICM + Planner": [[1, 0, 0], [0, 1, 1, 0]],
     }
     output = tmp_path / "violation_compare.pdf"
     plot_violation_comparison(logs, str(output))


### PR DESCRIPTION
## Summary
- Implement `plot_violation_comparison` to overlay mean violation probabilities with 95% CI for multiple methods
- Exercise the function in tests with variable-length dummy logs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d81817ae08330bb0094ea06ece034