### PR TITLE
Scale mask rate metrics to percentages

### DIFF
--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -12,6 +12,7 @@ from train import (
     get_paired_arrays,
     compute_cohens_d,
     bootstrap_ci,
+    format_mean_ci,
 )
 from scipy.stats import ttest_rel
 from statsmodels.stats.multitest import multipletests
@@ -438,3 +439,8 @@ def test_bootstrap_ci_shrinkage():
     np.random.seed(0)
     _, ci_large = bootstrap_ci(large, n_resamples=1000)
     assert ci_large < ci_small
+
+
+def test_mask_rate_percentage_formatting():
+    formatted = format_mean_ci([0.1], scale=100)
+    assert formatted == "10.00 ± 0.00"

--- a/train.py
+++ b/train.py
@@ -2394,7 +2394,7 @@ def run(args):
                     flatten_metric(data["rewards"]))
             success = format_bootstrap_ci(flatten_metric(data["success"]))
             planner = format_mean_ci(data["planner_pct"], scale=100)
-            mask_rate = format_mean_ci(data["mask_rate"])
+            mask_rate = format_mean_ci(data["mask_rate"], scale=100)
             adherence = format_mean_ci(data["adherence_rate"])
             coverage = format_mean_ci(data["coverage"])
             min_dist = format_mean_ci(data["min_dist"])


### PR DESCRIPTION
## Summary
- format mask rate metrics as percentages when building results
- add unit test to verify mask rate formatting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689eff4e77c08330ae5229f7af5d2b42