### PR TITLE
Add env/algo config options to training script

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ or
 ```bash
 python train.py --config configs/default.yaml
 ```
+
+Separate environment and algorithm YAMLs can also be combined:
+
+```bash
+python train.py --env-config configs/env_8x8.yaml --algo-config configs/algo/lppo.yaml
+```
 To store generated figures run with `--plot-dir`:
 ```bash
 python train.py --config configs/default.yaml --plot-dir figures

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -237,6 +237,19 @@ def test_parse_args_danger_distance():
     assert args.danger_distance == 3
 
 
+def test_parse_args_env_algo_config():
+    args = parse_args([
+        "--env-config",
+        "configs/env_8x8.yaml",
+        "--algo-config",
+        "configs/algo/lppo.yaml",
+    ])
+    # grid_size from env config, disable_icm from algo config
+    assert args.grid_size == 8
+    assert args.disable_icm is True
+    assert args.num_episodes == 200
+
+
 def test_train_agent_with_shielding_and_bonus_decay(tmp_path):
     env = GridWorldICM(grid_size=4, max_steps=5)
     os.makedirs("maps", exist_ok=True)


### PR DESCRIPTION
## Summary
- allow train.py to load separate environment and algorithm YAML configs with `--env-config` and `--algo-config`
- merge these config defaults before parsing and fall back to `--config` for extra tweaks
- document new CLI usage and add tests for combined configs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a58ae62df4833091dd67f58cde561b