### PR TITLE
Add full experiment automation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,16 @@ maps in a consistent order with:
 Both scripts iterate deterministically so repeated invocations yield comparable
 results.
 
+Run the entire experiment suite with all algorithms, five random seeds and
+ablation settings by calling:
+
+```bash
+./scripts/full_experiment.sh
+```
+
+The script logs success or failure for the training run and, when successful,
+invokes evaluation and summary steps such as figure and table generation.
+
 ## Running Tests
 Execute the unit tests with:
 ```bash

--- a/scripts/full_experiment.sh
+++ b/scripts/full_experiment.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run the full experiment suite across all algorithms and seeds.
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT="$SCRIPT_DIR/.."
+cd "$REPO_ROOT"
+
+LOG_DIR="results/logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/full_experiment_$(date +%Y%m%d_%H%M%S).log"
+
+echo "=== Full experiment started at $(date) ===" | tee "$LOG_FILE"
+
+run_and_log() {
+  local name="$1"
+  shift
+  echo "--- ${name} ---" | tee -a "$LOG_FILE"
+  if "$@" >>"$LOG_FILE" 2>&1; then
+    echo "[SUCCESS] ${name}" | tee -a "$LOG_FILE"
+    return 0
+  else
+    local status=$?
+    echo "[FAILED] ${name} (exit code ${status})" | tee -a "$LOG_FILE"
+    return $status
+  fi
+}
+
+run_and_log "Training" python train.py --all-algos --seeds 0 1 2 3 4 --ablation --postprocess
+if [ $? -eq 0 ]; then
+  if [ -x "$SCRIPT_DIR/eval_all.sh" ]; then
+    run_and_log "Evaluation" "$SCRIPT_DIR/eval_all.sh"
+  fi
+  if [ -f "generate_figures.py" ]; then
+    run_and_log "Generate figures" python generate_figures.py
+  fi
+  if [ -f "generate_tables.py" ]; then
+    run_and_log "Generate tables" python generate_tables.py
+  fi
+fi
+
+echo "=== Full experiment finished at $(date) ===" | tee -a "$LOG_FILE"


### PR DESCRIPTION
## Summary
- Add `scripts/full_experiment.sh` to run full training across all algorithms and seeds, logging success or failure and optionally invoking evaluation and summary scripts
- Document how to run the new script in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a612f8eb6883309a3603a814c57c28