### PR TITLE
Allow multi-seed runs in run_all.sh

### DIFF
--- a/scripts/run_all.sh
+++ b/scripts/run_all.sh
@@ -13,8 +13,31 @@ ALGO_DIR="configs/algo"
 # Explicitly list algorithms to ensure deterministic ordering
 ALGOS=(dyna lppo planner_subgoal shielded)
 
+# Seeds to run; override by setting the SEEDS environment variable
+if [[ -z "${SEEDS+x}" ]]; then
+  SEEDS=(0 1 2 3 4)
+else
+  read -r -a SEEDS <<<"${SEEDS}"
+fi
+
 for algo in "${ALGOS[@]}"; do
-  echo "=== Running ${algo} ==="
-  python train.py --env-config "$ENV_CONFIG" --algo-config "${ALGO_DIR}/${algo}.yaml" --seed 0
-  echo
+  for seed in "${SEEDS[@]}"; do
+    echo "=== Running ${algo} seed ${seed} ==="
+    OUT_DIR="runs/${algo}/seed_${seed}"
+    mkdir -p "$OUT_DIR"
+    (
+      cd "$OUT_DIR"
+      python "$REPO_ROOT/train.py" \
+        --env-config "$REPO_ROOT/$ENV_CONFIG" \
+        --algo-config "$REPO_ROOT/$ALGO_DIR/${algo}.yaml" \
+        --seed "$seed"
+    )
+    echo
+  done
 done
+
+# Optionally generate summary figures/tables after all runs
+if [[ "${POSTPROCESS:-0}" -eq 1 ]]; then
+  python generate_figures.py
+  python generate_tables.py
+fi


### PR DESCRIPTION
## Summary
- Expand `run_all.sh` to iterate over seed arrays and algorithm configs
- Store each run in `runs/<algo>/seed_<n>` and optionally trigger figure/table generation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6a4cefb1483308083b6e2e9d63c12